### PR TITLE
Calculate mesh normals - the STL file might not include them

### DIFF
--- a/src/STLViewer.js
+++ b/src/STLViewer.js
@@ -51,6 +51,10 @@ class STLViewer extends Component {
 
       let loader = new THREE.STLLoader();
       loader.load(url, ( geometry ) => {
+        
+        // Calculate mesh noramls for MeshLambertMaterial.
+        geometry.computeFaceNormals();
+        geometry.computeVertexNormals();
 
         // Center the object
         geometry.center();


### PR DESCRIPTION
Hey,
This fixes an issue when some files are rendered "all black" even when the color is set. This happens because of missing normals data that the shader relies on.