### PR TITLE
THREE.js loader - set crossOrigin='' to support loading resources fro…

### DIFF
--- a/src/STLViewer.js
+++ b/src/STLViewer.js
@@ -50,6 +50,7 @@ class STLViewer extends Component {
       scene.add( directionalLight );
 
       let loader = new THREE.STLLoader();
+      loader.crossOrigin = '';
       loader.load(url, ( geometry ) => {
         
         // Calculate mesh noramls for MeshLambertMaterial.


### PR DESCRIPTION
…m external domains

In reference to: #3 