### PR TITLE
colored STL files - enable showing binary colors of STL file

### DIFF
--- a/dist/Paint.js
+++ b/dist/Paint.js
@@ -101,7 +101,6 @@ var Paint = function () {
     key: 'addSTLToScene',
     value: function addSTLToScene(reqId) {
       var _this = this;
-      var material;
 
       this.loader.crossOrigin = '';
       this.loader.load(this.url, function (geometry) {
@@ -115,19 +114,10 @@ var Paint = function () {
         // Center the object
         geometry.center();
 
-        if (geometry.hasColors) {
-          material = new _Three2.default.MeshPhongMaterial({
-            opacity: geometry.alpha,
-            vertexColors: _Three2.default.VertexColors
-          });
-        } else {
-          material = new _Three2.default.MeshLambertMaterial({
-            overdraw: true,
-            color: _this.modelColor
-          });
-        }
-
-        _this.mesh = new _Three2.default.Mesh(geometry, material);
+        _this.mesh = new _Three2.default.Mesh(geometry, new _Three2.default.MeshLambertMaterial({
+          overdraw: true,
+          color: _this.modelColor
+        }));
         // Set the object's dimensions
         geometry.computeBoundingBox();
         _this.xDims = geometry.boundingBox.max.x - geometry.boundingBox.min.x;

--- a/dist/Paint.js
+++ b/dist/Paint.js
@@ -101,6 +101,7 @@ var Paint = function () {
     key: 'addSTLToScene',
     value: function addSTLToScene(reqId) {
       var _this = this;
+      var material;
 
       this.loader.crossOrigin = '';
       this.loader.load(this.url, function (geometry) {
@@ -114,10 +115,19 @@ var Paint = function () {
         // Center the object
         geometry.center();
 
-        _this.mesh = new _Three2.default.Mesh(geometry, new _Three2.default.MeshLambertMaterial({
-          overdraw: true,
-          color: _this.modelColor
-        }));
+        if (geometry.hasColors) {
+          material = new _Three2.default.MeshPhongMaterial({
+            opacity: geometry.alpha,
+            vertexColors: _Three2.default.VertexColors
+          });
+        } else {
+          material = new _Three2.default.MeshLambertMaterial({
+            overdraw: true,
+            color: _this.modelColor
+          });
+        }
+
+        _this.mesh = new _Three2.default.Mesh(geometry, material);
         // Set the object's dimensions
         geometry.computeBoundingBox();
         _this.xDims = geometry.boundingBox.max.x - geometry.boundingBox.min.x;

--- a/src/Paint.js
+++ b/src/Paint.js
@@ -83,13 +83,19 @@ class Paint {
       // Center the object
       geometry.center();
 
-      this.mesh = new THREE.Mesh(
-        geometry,
-        new THREE.MeshLambertMaterial({
-          overdraw: true,
-          color: this.modelColor
-        })
-      );
+      let material = new THREE.MeshLambertMaterial({
+        overdraw: true,
+        color: this.modelColor
+      });
+
+      if (geometry.hasColors) {
+        material = new THREE.MeshPhongMaterial({
+          opacity: geometry.alpha,
+          vertexColors: THREE.VertexColors
+        });
+      }
+
+      this.mesh = new THREE.Mesh(geometry, material);
       // Set the object's dimensions
       geometry.computeBoundingBox();
       this.xDims = geometry.boundingBox.max.x - geometry.boundingBox.min.x;


### PR DESCRIPTION
I added the ability to read the binary colors of the file.
now, if the file has colors, it will be seen.
example for a colored file, from three.js official site: https://threejs.org/examples/models/stl/binary/colored.stl.

note: in that case, when there is binary colors, the modelColor parameter does not needed and will not affect.