### PR TITLE
Require a more specific version of halogenium

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prepublish": "yarn run build"
   },
   "dependencies": {
-    "halogenium": "^2.2.3",
+    "halogenium": ">= 2.2.3 < 2.3",
     "prop-types": "^15.6.1",
     "three": "^0.72.0",
     "three-orbit-controls": "^72.0.0"


### PR DESCRIPTION
Currently, installing the package raises the following error:
`npm ERR! peer dep missing: styled-components@^4.3.2, required by halogenium@2.3.0`

This is because in version 2.3.0 of halogenium, a peer dependency (styled-components@^4.3.2) was added to it.

This PR specifies a more specific required version of halogenium to avoid this issue.